### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This python package is everything you need to transmorgrify your packets:
 
 This package is intended to make creating and/or parsing packets on the fly quick and easy.  This is a wrapper around 
 the [`ctypes` module](https://docs.python.org/dev/library/ctypes.html) built-in to python. This package is designed 
-with influence from Django's modeling and will look familar to those that have used it. 
+with influence from Django's modeling and will look familiar to those that have used it.
 
 ## Why `CalPack`?
 
@@ -61,7 +61,7 @@ Creating custom packets is as easy as defining the fields:
 
 ## Upcoming Features:
 
-The following list is a set of major features that is planned to be worked on.  For a more exhautive list, view the 
+The following list is a set of major features that is planned to be worked on.  For a more exhaustive list, view the
 issues page, or if you have ZenHub installed, view our current board. 
 
 - [x] Ability to create a field with multiple words (i.e. a Data Array Field)
@@ -74,4 +74,4 @@ issues page, or if you have ZenHub installed, view our current board.
 
 ## Python 2 and 3
 Currently this module is designed to work for both Python 2.7+ and 3.3+, however, with the term of life for Python 2 in the 
-near future, further develpment of this package will eventually port entirely over to Python 3.  
+near future, further development of this package will eventually port entirely over to Python 3.

--- a/calpack/models/fields.py
+++ b/calpack/models/fields.py
@@ -43,7 +43,7 @@ class Field(object):
         """
         py_to_c - A function used to convert a python object into a valid ctypes assignable object.  As a default 
         this function simply returns :code:`val`.  It's up to the other :code:`Field`'s to define this if further 
-        formating is reuqired in order to set the internal structure of the packet.  
+        formatting is required in order to set the internal structure of the packet.
 
         :param val: the value the user is attempting to set the packet field to.  This can be any python object.
         """
@@ -51,9 +51,9 @@ class Field(object):
 
     def c_to_py(self, c_field):
         """
-        c_to_py - A function used to convert the cytpes object into a python object.  As a default this function
+        c_to_py - A function used to convert the ctypes object into a python object.  As a default this function
         simply returns :code:`c_field` directly from the ctypes.Structure object.  It's up to the other :code:`Field`'s
-        to define this if further formating is required in order to turn the cyptes value into something user friendly.
+        to define this if further formatting is required in order to turn the ctypes value into something user friendly.
 
         :param c_field: a ctypes object from the packet's internal :code:`ctypes.Structure` object
         """
@@ -63,7 +63,7 @@ class Field(object):
         """
         create_field_c_tuple - A function used to create the required an field in the :code:`ctypes.Structure._fields_` 
         tuple.  This must return a tuple that is acceptable for one of the items in the :code:`_fields_` list of the
-        :code:`cytpes.Structure`.  
+        :code:`ctypes.Structure`.
 
         The first value in the tuple MUST be :code:`self.field_name` as this is used to access the internal c 
         structure.  
@@ -73,7 +73,7 @@ class Field(object):
 
 class IntField(Field):
     """
-    An Integer field.  This field can be configured to be signed or unsinged.  It's bit length can also be set, 
+    An Integer field.  This field can be configured to be signed or unsigned.  It's bit length can also be set,
     however the max bit length for this field is 64.  
 
     :param int bit_len: the length in bits of the integer.  Max value of 64. (default 16)
@@ -84,7 +84,7 @@ class IntField(Field):
 
     signed = typed_property('signed', bool, False)
 
-    # TODO: Implement endianess processing
+    # TODO: Implement endianness processing
     little_endian = typed_property('little_endian', bool)
 
     def __init__(self, bit_len=16, signed=False, default_val=0, little_endian=False):
@@ -105,7 +105,7 @@ class IntField(Field):
 
     def py_to_c(self, val):
         if not self.signed and val < 0:
-            raise TypeError("Signed valued cannot be set for an unsiged IntField!")
+            raise TypeError("Signed valued cannot be set for an unsigned IntField!")
         return val
 
     def create_field_c_tuple(self, name):

--- a/calpack/models/packets.py
+++ b/calpack/models/packets.py
@@ -118,7 +118,7 @@ class Packet(object):
 
 
     :param c_pkt: (Optional) a :code:`ctypes.Structure` object that will be used at the internal c structure.  This
-        MUST have the same :code:`_feilds_` as the Packet would normally have in order for it to work properly.  
+        MUST have the same :code:`_fields_` as the Packet would normally have in order for it to work properly.
     """
     word_size = typed_property('word_size', int, 16)
     fields_order = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 CalPack: Packets in Python Simplified
 =====================================
 CalPack is the only package you'll need to create, generate and parse packets in an easy to use way.  This module wraps
-the :code:`cytpes` module into an easier to use interface and enabling more features specific to working with Packets.  
+the :code:`ctypes` module into an easier to use interface and enabling more features specific to working with Packets.
 
 
 Examples
@@ -35,7 +35,7 @@ Since :code:`calpak` is a wrapper to :code:`ctypes`, the above class is equivale
             ('checksum', ctypes.c_uint64, 16),
         ]
 
-Interactiong with the packet and it's field is also simple::
+Interacting with the packet and it's field is also simple::
 
     p = UDP()
     p.source_port = 80

--- a/docs/modelsdoc.rst
+++ b/docs/modelsdoc.rst
@@ -76,7 +76,7 @@ Packet fields can be easily copied from and/or compared to other packets of the 
     my_pkt.dest == my_pkt2.dest
     False
 
-Packets themself can also be compared::
+Packets themselves can also be compared::
 
     my_pkt = Header()
     my_pkt.source = 123
@@ -271,7 +271,7 @@ There are a few things to consider before creating a custom Field:
 
     1. There are specific properties that **must** be defined within the class
     2. Any methods defined must be a class method and cannot be used as an instance method
-    3. You must have a basic understanding of the :code:`cyptes` module specifically how to use the 
+    3. You must have a basic understanding of the :code:`ctypes` module specifically how to use the
         :code:`ctypes.Structure` class.  
 
 It is recommended that you study the way that `Structures <https://docs.python.org/3/library/ctypes.html#structures-and-unions/>`_
@@ -326,7 +326,7 @@ appropriate.  By default this function does exactly that::
     def py_to_c(self, val):
         return val
 
-However in certain cases additional formatting, transformation or validation might be requried.  Use this function
+However in certain cases additional formatting, transformation or validation might be required.  Use this function
 to override the behavior as needed.  
 
 :code:`c_to_py`

--- a/tests/IntField_Test.py
+++ b/tests/IntField_Test.py
@@ -19,7 +19,7 @@ class Test_IntField(unittest.TestCase):
     def test_intfield_set_valid_values(self):
         """
         This test verifies that setting an integer field of a packet is done correctly. This also verifies that the 
-        internal c structure is propertly setup as well.  
+        internal c structure is properly setup as well.
         """
         p = self.two_int_field_packet()
 
@@ -57,7 +57,7 @@ class Test_IntField(unittest.TestCase):
 
     def test_intfield_raises_TypeError_when_setting_signed_to_nonsigned(self):
         """
-        This test verifies that a "TypeErorr" is raised when setting a non-signed value to a
+        This test verifies that a "TypeError" is raised when setting a non-signed value to a
         signed value.  
         """
         p = self.two_int_field_packet()
@@ -82,7 +82,7 @@ class Test_IntField(unittest.TestCase):
         self.assertEqual(p.int_field, p2.int_field)
         self.assertEqual(p2._Packet__c_pkt.int_field, v1)
 
-    def test_intfield_with_variable_bit_lenth(self):
+    def test_intfield_with_variable_bit_length(self):
         """
         This test verifies that setting an integer value of variable size is correctly exported to the to_bytes 
         function.  This also tests the ability to set a value for the packet upon instantiation.  

--- a/tests/PacketField_Test.py
+++ b/tests/PacketField_Test.py
@@ -17,7 +17,7 @@ class Test_PacketField(unittest.TestCase):
 
          p = adv_pkt()
 
-         # Verify abilily to access and set encap packets fields
+         # Verify ability to access and set encap packets fields
          p.field2.field1 = 100
 
          self.assertEquals(p.field2.field1, 100)


### PR DESCRIPTION
old | new
--- | ---
  `formating` | `formatting`
  `reuqired` | `required`
  `cytpes` | `ctypes`
  `cyptes` | `ctypes`
  `unsinged` | `unsigned`
  `endianess` | `endianness`
  `unsiged` | `unsigned`
  `_feilds` | `fields`
  `parseable` | `parsable`
  `interactiong` | `interacting`
  `themself` | `themselves`
  `requried` | `required`
  `propertly` | `properly`
  `TypeErorr` | `TypeError`
  `lenth` | `length`
  `abilily` | `ability`
  `familar` | `familiar`
  `exhautive` | `exhaustive`
  `develpment` | `development`