### PR TITLE
Release 2018.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,5 @@ calpack.egg-info/
 *.pyproj
 *.pyperf
 .vscode/*
+
+\.pytest_cache\*

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ deploy:
       distributions: sdist bdist_wheel
       repo: KronoSKoderS/CalPack
       condition: TRAVIS_EVENT_TYPE != 'cron'
+      python: "3.6"
       
   - provider: releases
     skip_cleanup: true
@@ -51,6 +52,6 @@ deploy:
     file: $(build/*.tar.gz)
     on:
       repo: KronoSKoderS/CalPack
-      branch: tags
+      tags: true
       condition: TRAVIS_EVENT_TYPE != 'cron'
 

--- a/docs/user/fields_builtin_doc.rst
+++ b/docs/user/fields_builtin_doc.rst
@@ -102,7 +102,7 @@ The :code:`BoolField` is used to represent a :code:`bool` object in python.  Thi
 -----------------
 
 The :code:`FlagField` is used to represent a "flag" in the packet.  This is a single bit integer and
-can only store a value of 1 or 0.  This field is similar to :code:`IntField(bit_len=1)`.  
+can only store a value of 1 or 0.  This field is similar to :code:`IntField8(bit_len=1)`.  
 
 :code:`PacketField`
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = "0.1.3"
+version = "2018.5.0"
 
 try:
     import pypandoc
@@ -42,5 +42,5 @@ setup(
         'Topic :: Utilities',
     ],
     test_suite="tests.get_tests",
-    packages=find_packages(exclude=['tests'])
+    packages=find_packages(exclude=['tests', 'docs'])
 )

--- a/tests/test_BasicPackets.py
+++ b/tests/test_BasicPackets.py
@@ -173,6 +173,21 @@ class Test_BasicPacket(unittest.TestCase):
         self.assertNotEqual(p1.int_field, p2.int_field)
         self.assertNotEqual(p1.int_field_signed, p2.int_field_signed)
 
+    def test_pkt_len(self):
+        class simple_pkt(models.Packet):
+            int_field = models.IntField()
+            int_field_signed = models.IntField(signed=True)
+
+        class c_simple_pkt(ctypes.Structure):
+            _fields_ = (
+                ('int_field', ctypes.c_uint),
+                ('int_field_signed', ctypes.c_int)
+            )
+
+        p1 = simple_pkt()
+
+        self.assertEqual(len(p1), ctypes.sizeof(c_simple_pkt))
+
 
 class Test_EndianPacket(unittest.TestCase):
 


### PR DESCRIPTION
* updated travis-ci to only push to pypi from the python 3 build

* python version needs to be in quotations.

* fixing tags deployment

* updated test to properly grab size

* Ignoring pytest caches files.

* Added ability to get the `len` of a Packet.

* added test to verify proper inheritance of Packet class.

* working on updating the inheritance of Packet class

* fixed issue with inheritance.

* Inheritance (#86)

* added test to verify proper inheritance of Packet class.

* working on updating the inheritance of Packet class

* fixed issue with inheritance.

* fixed FlagField documentation.

* Updating to a new release version of <year>.<month>.<minor>